### PR TITLE
Fix arrow pointer error

### DIFF
--- a/BST/bst.cpp
+++ b/BST/bst.cpp
@@ -10,53 +10,53 @@ struct node {
 };
 struct node * insert(int n) {
   struct node * temp = new struct node();
-  temp - > val = n;
-  temp - > left = NULL;
-  temp - > right = NULL;
+  temp -> val = n;
+  temp -> left = NULL;
+  temp -> right = NULL;
   return temp;
 }
 void inorder(struct node * root) {
   if (root != NULL) {
-    inorder(root - > left);
-    cout << root - > val << " ";
-    arr.push_back(root - > val);
-    inorder(root - > right);
+    inorder(root -> left);
+    cout << root -> val << " ";
+    arr.push_back(root -> val);
+    inorder(root -> right);
   }
 }
 void postorder(struct node * root) {
   if (root != NULL) {
-    postorder(root - > right);
-    postorder(root - > left);
-    cout << root - > val << " ";
+    postorder(root -> right);
+    postorder(root -> left);
+    cout << root -> val << " ";
   }
 }
 void preorder(struct node * root) {
   if (root != NULL) {
-    cout << root - > val << " ";
-    preorder(root - > left);
-    preorder(root - > right);
+    cout << root -> val << " ";
+    preorder(root -> left);
+    preorder(root -> right);
   }
 }
 struct node * create(struct node * root, int n) {
   if (root == NULL)
     insert(n);
-  else if (root - > val > n) {
-    root - > left = create(root - > left, n);
+  else if (root -> val > n) {
+    root -> left = create(root -> left, n);
   } else
-    root - > right = create(root - > right, n);
+    root -> right = create(root -> right, n);
 }
 
 bool find(struct node * root, int key) {
-  if (root - > val > key && root - > left == NULL)
+  if (root -> val > key && root -> left == NULL)
     return 0;
-  if (root - > val < key && root - > right == NULL)
+  if (root -> val < key && root -> right == NULL)
     return 0;
-  if (root - > val == key)
+  if (root -> val == key)
     return 1;
-  else if (root - > val > key) {
-    find(root - > left, key);
-  } else if (root - > val < key) {
-    find(root - > right, key);
+  else if (root -> val > key) {
+    find(root -> left, key);
+  } else if (root -> val < key) {
+    find(root -> right, key);
   } else
     return 0;
 }


### PR DESCRIPTION
Last version compiled encounter `error: expected primary-expression before ‘>’ token`, fixed.