### PR TITLE
binsearch-bug

### DIFF
--- a/Search/BinarySearch/BinarySearch.py
+++ b/Search/BinarySearch/BinarySearch.py
@@ -1,5 +1,5 @@
 def Binary_search(arr, start_index, last_index, element):
-    mid = (int)(start_index + last_index) / 2
+    mid = (int)(start_index + (last_index - start_index)) / 2
 
     if (start_index > last_index):
         print("Element not found")

--- a/Search/BinarySearch/binarysearch_lightning.java
+++ b/Search/BinarySearch/binarysearch_lightning.java
@@ -20,7 +20,7 @@ public class Binary_search {
 		int left = 0, right = A.length - 1;
 
 		while (left <= right) {
-			int mid = (left + right) / 2;
+			int mid = (left + (right - left)) / 2;
 			if (data > A[mid]) {
 				left = mid + 1;
 			} else if (data < A[mid]) {

--- a/Search/BinarySearch/bsearch.cpp
+++ b/Search/BinarySearch/bsearch.cpp
@@ -15,7 +15,7 @@ bool binary_search(int number)
 
     do
     {
-        mid = (higher + lower) / 2;
+        mid = (lower + (higher - lower)) / 2;
         if (number == myarray[mid])
         {
             std::cout << "found at pos: " << mid + 1 << std::endl;


### PR DESCRIPTION
Corrected the famous binary search bug: when searching for the middle element of an array it is unsafe to do midlle = (high + low) /2 because it can lead to an overflow error, the safe version is
 middle = (low + (high - low))/2.