### PR TITLE
KMP Algorithm for finding given pattern in text

### DIFF
--- a/String/String Matching/KMP_ALGO_stringMatching.cpp
+++ b/String/String Matching/KMP_ALGO_stringMatching.cpp
@@ -1,0 +1,69 @@
+#include <bits/stdc++.h>
+#define N 100000
+using namespace std;
+
+/* creating lps array (longest proper prefix) 
+		proper prefix - prefix with whole string not allowed */
+int lps[N];
+
+void LPSArray(string pattern){
+	int i=1,length = 0;
+	lps[0] = 0;	// lps[0] is always 0
+
+	int n = pattern.size();
+
+	while(i < n){
+		if(pattern[i] == pattern[length]){
+			length++;
+			lps[i] = length;
+			i++;
+		}
+		else{
+			if(length != 0){
+				length = lps[length-1];
+			}
+			else{
+				lps[i] = 0;
+				i++;
+			}
+		}
+	}
+}
+
+void KMP(string text, string pattern){
+	int n = text.size();
+	int m = pattern.size();
+
+	LPSArray(pattern);
+
+	int i=0,j=0;
+	while(i < n){
+		if(pattern[j] == text[i]){
+			i++;
+			j++;
+		}
+
+		// after j successfull matches
+		if(j == m){
+			cout<<"Pattern found at index "<<i-j<<endl;
+			j = lps[j-1];
+		}
+		// mismatch happened after j matches
+		else if( i<n and pattern[j] != text[i]){
+			if( j != 0)
+				j = lps[j-1];
+			else
+				i++;
+		}
+	}
+}
+
+int main(){
+	cout<<"Enter Text: ";
+	string text,pattern;
+	cin>>text;
+	cout<<"Enter Pattern: ";
+	cin>>pattern;
+	KMP(text,pattern);
+
+}


### PR DESCRIPTION
How to use lps[] to decide next positions (or to know a number of characters to be skipped)?

    We start comparison of pat[j] with j = 0 with characters of current window of text.
    We keep matching characters txt[i] and pat[j] and keep incrementing i and j while pat[j] and txt[i] keep matching.
    When we see a mismatch
        We know that characters pat[0..j-1] match with txt[i-j+1…i-1] (Note that j starts with 0 and increment it only when there is a match).
        We also know (from above definition) that lps[j-1] is count of characters of pat[0…j-1] that are both proper prefix and suffix.
        From above two points, we can conclude that we do not need to match these lps[j-1] characters with txt[i-j…i-1] because we know that these characters will anyway match.